### PR TITLE
Include symlinks in manpage dump

### DIFF
--- a/cmd/xmandump/main.go
+++ b/cmd/xmandump/main.go
@@ -381,7 +381,7 @@ func (d *Dumper) processPackage(ctx context.Context, pkg *xrepo.Package, file st
 
 scanPackage:
 	manpages = map[string]struct{}{}
-	for _, file := range files.Files {
+	for _, file := range append(files.Files, files.Links...) {
 		if strings.HasPrefix(file.File, manDirsPrefix) {
 			pkgfile := "." + file.File
 			manpages[pkgfile] = struct{}{}
@@ -474,6 +474,7 @@ func logClose(ctx context.Context, c io.Closer) (err error) {
 type packageFiles struct {
 	Files []packageFile `plist:"files"`
 	Dirs  []packageFile `plist:"dirs"`
+	Links []packageFile `plist:"links"`
 }
 
 func (p *packageFiles) Empty() bool {


### PR DESCRIPTION
Fixes #7

Did a little testing locally and was able to get this for a small binpkgs directory:

```
man-cgi
└── x86_64
    ├── cache.json
    ├── man1
    │   ├── xbarf.1 -> xtools.1
    │   ├── xbuildbarf.1 -> xtools.1
    │   ├── xbulk.1 -> xtools.1
    │   ├── xbump.1 -> xtools.1
    │   ├── xcheckmypkgs.1 -> xtools.1
    │   ├── xcheckrestart.1 -> xtools.1
    │   ├── xchroot.1 -> xtools.1
    │   ├── xclash.1 -> xtools.1
    │   ├── xdbg.1 -> xtools.1
    │   ├── xdiff.1 -> xtools.1
    │   ├── xdistdir.1 -> xtools.1
    │   ├── xdowngrade.1 -> xtools.1
    │   ├── xetcchanges.1 -> xtools.1
    │   ├── xgensum.1 -> xtools.1
    │   ├── xgrep.1 -> xtools.1
    │   ├── xhog.1 -> xtools.1
    │   ├── xi.1 -> xtools.1
    │   ├── xilog.1 -> xtools.1
    │   ├── xlg.1 -> xtools.1
    │   ├── xlint.1 -> xtools.1
    │   ├── xlocate.1 -> xtools.1
    │   ├── xlog.1 -> xtools.1
    │   ├── xls.1 -> xtools.1
    │   ├── xmandoc.1 -> xtools.1
    │   ├── xmksv.1 -> xtools.1
    │   ├── xmypkgs.1 -> xtools.1
    │   ├── xnew.1 -> xtools.1
    │   ├── xnodev.1 -> xtools.1
    │   ├── xoptdiff.1 -> xtools.1
    │   ├── xpcdeps.1 -> xtools.1
    │   ├── xpkg.1 -> xtools.1
    │   ├── xpkgdiff.1 -> xtools.1
    │   ├── xpstree.1 -> xtools.1
    │   ├── xq.1 -> xtools.1
    │   ├── xrecent.1 -> xtools.1
    │   ├── xrevbump.1 -> xtools.1
    │   ├── xrevshlib.1 -> xtools.1
    │   ├── xrs.1 -> xtools.1
    │   ├── xsrc.1 -> xtools.1
    │   ├── xsubpkg.1 -> xtools.1
    │   ├── xtools.1
    │   ├── xuname.1 -> xtools.1
    │   └── xvoidstrap.1 -> xtools.1
    ├── man8
    │   ├── dosfsck.8 -> fsck.fat.8
    │   ├── dosfslabel.8 -> fatlabel.8
    │   ├── fatlabel.8
    │   ├── fsck.fat.8
    │   ├── fsck.msdos.8 -> fsck.fat.8
    │   ├── fsck.vfat.8 -> fsck.fat.8
    │   ├── mkdosfs.8 -> mkfs.fat.8
    │   ├── mkfs.fat.8
    │   ├── mkfs.msdos.8 -> mkfs.fat.8
    │   └── mkfs.vfat.8 -> mkfs.fat.8
    └── mandoc.db
```

Wasn't able to test if it works with the final output ui (couldn't figure out how to setup it up), but from reading mandoc.db(5) i think links should be handled