### PR TITLE
fix leak of zstd decoder resources, add cpu and mem profile options

### DIFF
--- a/cmd/xmandump/main.go
+++ b/cmd/xmandump/main.go
@@ -277,7 +277,6 @@ func (d *Dumper) processRepoData(ctx context.Context, file string) (err error) {
 
 		wg.Go(func() error {
 			defer d.Sema.Release(2)
-			defer runtime.GC()
 			return d.processPackage(ctx, pkg, pkgfile)
 		})
 	}


### PR DESCRIPTION
### fix leak of zstd decoder resources

Each job works on one file, so the decoder is not shared across
routines. If we fail to close the decoders after use, they pile up.

### add cpu and mem profile options

Add flags to write CPU and/or memory profiles