### PR TITLE
cmd/xmandump/main: always check if dumped file exists and remove

### DIFF
--- a/cmd/xmandump/main.go
+++ b/cmd/xmandump/main.go
@@ -488,6 +488,15 @@ func (d *Dumper) processPackageFile(ctx context.Context, pkg *xrepo.Package, hdr
 	if d.Compress {
 		relpath += ".gz"
 	}
+
+	// check if a file already exists and remove it
+	if _, err := os.Lstat(relpath); err == nil {
+		if err := os.Remove(relpath); err != nil {
+			Error(ctx, "Unable to remove existing file")
+			return err
+		}
+	}
+
 	if !symlink {
 		// TODO: Dump manpage to filesystem after stripping usr/share/ prefix
 		f, err := os.Create(relpath)
@@ -507,13 +516,6 @@ func (d *Dumper) processPackageFile(ctx context.Context, pkg *xrepo.Package, hdr
 			return err
 		}
 	} else {
-		// check if a file already exists and remove it
-		if _, err := os.Lstat(relpath); err == nil {
-			if err := os.Remove(relpath); err != nil {
-				Error(ctx, "Unable to remove existing file")
-				return err
-			}
-		}
 		lname := hdr.Linkname
 		if d.Compress {
 			lname += ".gz"


### PR DESCRIPTION
just `os.Create()` seems to have caused intermittent corruption when mulitple packages contain the same manpage. ideally we'd keep all versions of the manpage separately, but I don't think we can do that while still using man-cgi.

before:
```
$ find . -name *.gz -exec gzip -t {} \;
gzip: ./armv7l/man3/dblink_connect.3.gz: decompression OK, trailing garbage ignored
gzip: ./armv7l/man3/SPI_fname.3.gz: unexpected end of file
gzip: ./armv7l/man3/SPI_repalloc.3.gz: invalid compressed data--format violated
gzip: ./armv7l/man3/SPI_exec.3.gz: invalid compressed data--format violated
gzip: ./armv7l/man3/SPI_keepplan.3.gz: unexpected end of file
gzip: ./armv7l/man3/dblink_build_sql_delete.3.gz: invalid compressed data--format violated
```
after:
```
$ find . -name *.gz -exec gzip -t {} \;
(nothing)
```